### PR TITLE
Add etherlink.test.json with transaction test case

### DIFF
--- a/etherlink.test.json
+++ b/etherlink.test.json
@@ -1,0 +1,14 @@
+{
+  "chainId": "etherlink",
+  "tests": [
+    {
+      "txHash": "0xd4fe88fac8f8ba8ab31cb08e0a9674e9c1de6a437522354a427b739058cb7221",
+      "expected": [
+        {
+          "from": "0x529e1f4a0a33645156d8A976C63f83584279366e",
+          "to": "0x89757Cfed2Baab244c321e0fe252669cFF89F47A"
+        }
+      ]
+    }
+  ]
+} 


### PR DESCRIPTION
This commit adds the etherlink.test.json file under test/chains/ for ERC4337 configuration. It includes:
- chainId set to "etherlink"
- Test transaction hash with expected from (user) and to (smart contract) addresses This file will be used for validating transaction parsing on the DappRadar ERC4337 configuration repository.